### PR TITLE
Add permissions to shared workflow files [AB#97912]

### DIFF
--- a/.github/workflows/shared-app-cd-workflow.yaml
+++ b/.github/workflows/shared-app-cd-workflow.yaml
@@ -1,9 +1,7 @@
 name: Shared Application CD Workflow
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-cd-workflow.yaml
+++ b/.github/workflows/shared-app-cd-workflow.yaml
@@ -1,6 +1,7 @@
 name: Shared Application CD Workflow
 
 permissions:
+  id-token: write
   contents: read
 on:
   workflow_call:

--- a/.github/workflows/shared-app-cd-workflow.yaml
+++ b/.github/workflows/shared-app-cd-workflow.yaml
@@ -1,5 +1,9 @@
 name: Shared Application CD Workflow
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-ci-workflow.yaml
+++ b/.github/workflows/shared-app-ci-workflow.yaml
@@ -1,5 +1,9 @@
 name: Shared Application CI Workflow
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-ci-workflow.yaml
+++ b/.github/workflows/shared-app-ci-workflow.yaml
@@ -1,9 +1,7 @@
 name: Shared Application CI Workflow
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-deployment-workflow.yaml
+++ b/.github/workflows/shared-app-deployment-workflow.yaml
@@ -3,7 +3,6 @@ name: Shared Application Deployment Workflow
 permissions:
   id-token: write
   contents: read
-  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-deployment-workflow.yaml
+++ b/.github/workflows/shared-app-deployment-workflow.yaml
@@ -1,5 +1,9 @@
 name: Shared Application Deployment Workflow
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-integration-tests-workflow.yaml
+++ b/.github/workflows/shared-app-integration-tests-workflow.yaml
@@ -1,5 +1,9 @@
 name: Shared Application Integration Tests Workflow
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-integration-tests-workflow.yaml
+++ b/.github/workflows/shared-app-integration-tests-workflow.yaml
@@ -3,7 +3,6 @@ name: Shared Application Integration Tests Workflow
 permissions:
   id-token: write
   contents: read
-  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-package-workflow.yaml
+++ b/.github/workflows/shared-app-package-workflow.yaml
@@ -1,5 +1,9 @@
 name: Shared Application Package Workflow
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-app-package-workflow.yaml
+++ b/.github/workflows/shared-app-package-workflow.yaml
@@ -3,7 +3,6 @@ name: Shared Application Package Workflow
 permissions:
   id-token: write
   contents: read
-  pull-requests: read
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/shared-failed-build-notification-workflow.yaml
+++ b/.github/workflows/shared-failed-build-notification-workflow.yaml
@@ -1,5 +1,8 @@
 name: Shared Failed Build Notification Workflow
 
+permissions:
+  actions: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
Shared reusable workflows were missing explicit `permissions` blocks.

When a caller CI/CD workflow defines permissions and invokes a reusable workflow that lacks its own `permissions` block, GitHub grants the **default read-all** token permissions to the shared job - defeating the least-privilege intent of the caller's permission declaration.

## Changes
Added the following `permissions` block to all shared `workflow_call` YAML files in this repo:

```yaml
permissions:
  id-token: write
  contents: read
  pull-requests: read
```

## References
- [GitHub Docs: Permissions for reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)

Fixes [AB#97912](https://dev.azure.com/UnipharGroup/1e9ac0ee-c51c-4a3d-999c-dc4177e29bcb/_workitems/edit/97912)